### PR TITLE
Switch Dockerfile to use distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,8 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o go-fail main.go
 
-FROM alpine:latest
+FROM gcr.io/distroless/static-debian12
 
-RUN apk --no-cache add ca-certificates
 WORKDIR /app
 
 COPY --from=builder /app/go-fail .


### PR DESCRIPTION
Replace Alpine Linux base image with gcr.io/distroless/static-debian12 for improved security and smaller image size. Distroless images contain only the application and its runtime dependencies without shell or package managers, reducing attack surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)